### PR TITLE
Define index commands as noops.

### DIFF
--- a/lib/arjdbc/vertica/adapter.rb
+++ b/lib/arjdbc/vertica/adapter.rb
@@ -25,6 +25,10 @@ module ::ArJdbc
       ADAPTER_NAME
     end
 
+    def add_index(*args)
+      # no op
+    end
+
     ##
     # Vertica JDBC does not work with JDBC GET_GENERATED_KEYS
     # so we need to execute the sql raw and then lookup the 
@@ -60,8 +64,12 @@ module ::ArJdbc
       quote_column_name(attr)
     end
 
+    def remove_index(*args)
+      # no op
+    end
+
     def rename_index(*args)
-      raise ArgumentError, "rename_index does not work on Vertica"
+      # no op
     end
 
   end


### PR DESCRIPTION
Vertica does not have indexes, so this will make all index commands no-ops.
