### PR TITLE
Override ActiveRecord rake db:test:purge task

### DIFF
--- a/lib/activerecord-jdbcvertica-adapter.rb
+++ b/lib/activerecord-jdbcvertica-adapter.rb
@@ -1,2 +1,4 @@
 require "activerecord-jdbcvertica-adapter/version"
 require "active_record"
+
+require 'activerecord-jdbcvertica-adapter/railtie' if defined?(Rails)

--- a/lib/activerecord-jdbcvertica-adapter/railtie.rb
+++ b/lib/activerecord-jdbcvertica-adapter/railtie.rb
@@ -1,0 +1,11 @@
+module Activerecord::Jdbcvertica::Adapter
+  class Railtie < ::Rails::Railtie
+
+    rake_tasks do
+      if defined?(Rake)
+        load "tasks/vertica_database_tasks.rake"
+      end
+    end
+
+  end
+end

--- a/lib/tasks/vertica_database_tasks.rake
+++ b/lib/tasks/vertica_database_tasks.rake
@@ -1,0 +1,15 @@
+# Override rails database tasks since vertica database cannot be dropped/created
+# with commands from the appliation
+
+::Rake::Task["db:test:purge"].clear if ::Rake::Task.task_defined?("db:test:purge")
+
+namespace :db do
+  namespace :test do
+    task :purge => [:environment, :load_config] do
+      ::ActiveRecord::Base.establish_connection(:test)
+      ::ActiveRecord::Base.connection.tables.each do |table|
+        ::ActiveRecord::Base.connection.drop_table(table)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows rails tests to be run via rake against a vertica database.

ActiveRecord attempts to drop the database when purging the test
database, however vertica does not allow databases to be dropped via SQL
commands.  Instead, we will just drop all of the tables.
