### PR TITLE
Return nil if table has no primary key

### DIFF
--- a/lib/arjdbc/vertica/adapter.rb
+++ b/lib/arjdbc/vertica/adapter.rb
@@ -199,7 +199,7 @@ module ::ArJdbc
       return @primary_keys[table_name] if @primary_keys[table_name]
 
       keys = self.execute("SELECT column_name FROM v_catalog.primary_keys WHERE table_name = '#{table_name}';")
-      @primary_keys[table_name] = [ keys.first['column_name'] ]
+      @primary_keys[table_name] = [ keys.first && keys.first['column_name'] ]
       @primary_keys[table_name]
     end
 


### PR DESCRIPTION
If a table has no primary key (like the rails schema migrations table)
we should return nil instead of allow an error to be raised.  Other
database adapters return nil, and the schema migrations expects it to be
nil in the schema migrations rake tasks.

[Here is how the jdbc postgres adapter implements the same method](https://github.com/jruby/activerecord-jdbc-adapter/blob/master/lib/arjdbc/postgresql/adapter.rb#L478)
