### PR TITLE
add multiple hosts config for databas.yml

### DIFF
--- a/lib/arjdbc/vertica/connection_methods.rb
+++ b/lib/arjdbc/vertica/connection_methods.rb
@@ -1,7 +1,30 @@
 class ActiveRecord::Base
+  def self.parse_port_from_host(host)
+    # looking for vertica_host_1:2098
+    return nil unless host.include?(":")
+    host.split(":").last
+  end
+
+  def self.trim_port_from_host(host)
+    return host unless host.include?(":")
+    host_parts = host.split(":")
+    host_parts.pop
+    host_parts.join(":")
+  end
+
   def self.vertica5_connection(config)
-    config[:port] ||= 5433
-    config[:url] = "jdbc:vertica://#{config[:host]}:#{config[:port]}/#{config[:database]}"
+    current_host = nil
+    current_port = nil
+
+    if config[:hosts] && config[:hosts].is_a?(Array)
+      current_host = config[:hosts].sample
+      current_port = parse_port_from_host(current_host)
+      current_host = trim_port_from_host(current_host)
+    end
+
+    current_host ||= config[:host]
+    current_port ||= config[:port]
+    config[:url] = "jdbc:vertica://#{current_host}:#{current_port}/#{config[:database]}"
     config[:driver] = "com.vertica.jdbc.Driver"
     config[:prepared_statements] = false
     config[:connection_alive_sql] = "SELECT 1;"


### PR DESCRIPTION
@brianstien adding multiple hosts via the `config[:hosts]` key in a way that is backwards compat

(both hosts and host can be present, but if hosts are present it will choose a random server to execute the query on)