### PR TITLE
Update for rails 5 and ARJDBC-adapter 51.2

### DIFF
--- a/activerecord-jdbcvertica-adapter.gemspec
+++ b/activerecord-jdbcvertica-adapter.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.licenses      = [ "MIT" ]
 
-  gem.add_dependency "activerecord"
-  gem.add_dependency "activerecord-jdbc-adapter"
+  gem.add_dependency "activerecord", "5.1.6.2"
+  gem.add_dependency "activerecord-jdbc-adapter", "51.2"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "mocha"

--- a/activerecord-jdbcvertica-adapter.gemspec
+++ b/activerecord-jdbcvertica-adapter.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake"
+  gem.add_development_dependency "rspec"
 end

--- a/lib/activerecord-jdbcvertica-adapter/version.rb
+++ b/lib/activerecord-jdbcvertica-adapter/version.rb
@@ -1,7 +1,7 @@
 module Activerecord
   module Jdbcvertica
     module Adapter
-      VERSION = "0.2.0"
+      VERSION = "0.3.0.pre"
     end
   end
 end

--- a/lib/arjdbc/vertica/adapter.rb
+++ b/lib/arjdbc/vertica/adapter.rb
@@ -46,30 +46,34 @@ module ::ArJdbc
   module Vertica
     include ::ArJdbc::Util::QuotedCache
 
+    def self.jdbc_connection_class
+      ::ActiveRecord::ConnectionAdapters::JdbcConnection
+    end
+
     ADAPTER_NAME = 'Vertica'.freeze
     INSERT_TABLE_EXTRACTION = /into\s+(?<table_name>[^\(]*).*values\s*\(/im
 
     NATIVE_DATABASE_TYPES = {
-      :primary_key => "INTEGER NOT NULL PRIMARY KEY",
-      :string      => { :name => "varchar", :limit => 255 },
-      :text        => { :name => "varchar", :limit => 15000 },
-      :integer     => { :name => "integer" },
-      :float       => { :name => "float" },
-      :decimal     => { :name => "decimal" },
-      :datetime    => { :name => "datetime" },
-      :timestamp   => { :name => "timestamp" },
-      :time        => { :name => "time" },
-      :date        => { :name => "date" },
-      :binary      => { :name => "bytea" },
-      :boolean     => { :name => "boolean" },
-      :xml         => { :name => "xml" }
+        :primary_key => "INTEGER NOT NULL PRIMARY KEY",
+        :string      => { :name => "varchar", :limit => 255 },
+        :text        => { :name => "varchar", :limit => 15000 },
+        :integer     => { :name => "integer" },
+        :float       => { :name => "float" },
+        :decimal     => { :name => "decimal" },
+        :datetime    => { :name => "datetime" },
+        :timestamp   => { :name => "timestamp" },
+        :time        => { :name => "time" },
+        :date        => { :name => "date" },
+        :binary      => { :name => "bytea" },
+        :boolean     => { :name => "boolean" },
+        :xml         => { :name => "xml" }
     }
 
     TIMESTAMP_COLUMNS = [
-      "created_at",
-      "created_on",
-      "updated_at",
-      "updated_on"
+        "created_at",
+        "created_on",
+        "updated_at",
+        "updated_on"
     ]
 
     def self.current_time
@@ -110,12 +114,12 @@ module ::ArJdbc
 
       columns = raw_columns.map do |raw_column|
         ::ActiveRecord::ConnectionAdapters::VerticaColumn.new(
-          raw_column['column_name'],
-          raw_column['column_default'],
-          raw_column['data_type_id'],
-          raw_column['data_type'],
-          raw_column['is_nullable'], 
-          raw_column['is_identity']
+            raw_column['column_name'],
+            raw_column['column_default'],
+            raw_column['data_type_id'],
+            raw_column['data_type'],
+            raw_column['is_nullable'],
+            raw_column['is_identity']
         )
       end
 
@@ -162,7 +166,7 @@ module ::ArJdbc
 
     ##
     # Vertica JDBC does not work with JDBC GET_GENERATED_KEYS
-    # so we need to execute the sql raw and then lookup the 
+    # so we need to execute the sql raw and then lookup the
     # LAST_INSERT_ID() that occurred in this "session"
     #
     def exec_insert(sql, name, binds, primary_key = nil, sequence_name = nil)
@@ -177,7 +181,7 @@ module ::ArJdbc
 
     def native_database_types
       NATIVE_DATABASE_TYPES
-    end 
+    end
 
     def next_insert_id_for(sequence_name)
       return select_value("SELECT NEXTVAL('#{sequence_name}');")
@@ -284,5 +288,19 @@ end
 module ActiveRecord::ConnectionAdapters
   class VerticaAdapter < JdbcAdapter
     include ::ArJdbc::Vertica
+    def initialize(connection, logger = nil, connection_parameters = nil, config = {})
+
+
+      super(connection, logger, config) # configure_connection happens in super
+
+      initialize_type_map(@type_map = ::ActiveRecord::Type::HashLookupTypeMap.new)
+
+    end
+
+    def jdbc_connection_class(spec)
+      ::ArJdbc::Vertica.jdbc_connection_class
+    end
+
+
   end
 end

--- a/lib/arjdbc/vertica/adapter.rb
+++ b/lib/arjdbc/vertica/adapter.rb
@@ -54,26 +54,26 @@ module ::ArJdbc
     INSERT_TABLE_EXTRACTION = /into\s+(?<table_name>[^\(]*).*values\s*\(/im
 
     NATIVE_DATABASE_TYPES = {
-        :primary_key => "INTEGER NOT NULL PRIMARY KEY",
-        :string      => { :name => "varchar", :limit => 255 },
-        :text        => { :name => "varchar", :limit => 15000 },
-        :integer     => { :name => "integer" },
-        :float       => { :name => "float" },
-        :decimal     => { :name => "decimal" },
-        :datetime    => { :name => "datetime" },
-        :timestamp   => { :name => "timestamp" },
-        :time        => { :name => "time" },
-        :date        => { :name => "date" },
-        :binary      => { :name => "bytea" },
-        :boolean     => { :name => "boolean" },
-        :xml         => { :name => "xml" }
+      :primary_key => "INTEGER NOT NULL PRIMARY KEY",
+      :string      => { :name => "varchar", :limit => 255 },
+      :text        => { :name => "varchar", :limit => 15000 },
+      :integer     => { :name => "integer" },
+      :float       => { :name => "float" },
+      :decimal     => { :name => "decimal" },
+      :datetime    => { :name => "datetime" },
+      :timestamp   => { :name => "timestamp" },
+      :time        => { :name => "time" },
+      :date        => { :name => "date" },
+      :binary      => { :name => "bytea" },
+      :boolean     => { :name => "boolean" },
+      :xml         => { :name => "xml" }
     }
 
     TIMESTAMP_COLUMNS = [
-        "created_at",
-        "created_on",
-        "updated_at",
-        "updated_on"
+      "created_at",
+      "created_on",
+      "updated_at",
+      "updated_on"
     ]
 
     def self.current_time
@@ -114,12 +114,12 @@ module ::ArJdbc
 
       columns = raw_columns.map do |raw_column|
         ::ActiveRecord::ConnectionAdapters::VerticaColumn.new(
-            raw_column['column_name'],
-            raw_column['column_default'],
-            raw_column['data_type_id'],
-            raw_column['data_type'],
-            raw_column['is_nullable'],
-            raw_column['is_identity']
+          raw_column['column_name'],
+          raw_column['column_default'],
+          raw_column['data_type_id'],
+          raw_column['data_type'],
+          raw_column['is_nullable'],
+          raw_column['is_identity']
         )
       end
 
@@ -289,18 +289,12 @@ module ActiveRecord::ConnectionAdapters
   class VerticaAdapter < JdbcAdapter
     include ::ArJdbc::Vertica
     def initialize(connection, logger = nil, connection_parameters = nil, config = {})
-
-
       super(connection, logger, config) # configure_connection happens in super
-
       initialize_type_map(@type_map = ::ActiveRecord::Type::HashLookupTypeMap.new)
-
     end
 
     def jdbc_connection_class(spec)
       ::ArJdbc::Vertica.jdbc_connection_class
     end
-
-
   end
 end

--- a/lib/arjdbc/vertica/adapter.rb
+++ b/lib/arjdbc/vertica/adapter.rb
@@ -79,6 +79,25 @@ module ::ArJdbc
       "updated_on"
     ]
 
+    def columns(table_name, name = nil)
+      sql = "SELECT * from V_CATALOG.COLUMNS WHERE table_name = '#{table_name}';"
+      raw_columns = execute(sql, name || "SCHEMA")
+
+      columns = raw_columns.map do |raw_column|
+        ::ActiveRecord::ConnectionAdapters::VerticaColumn.new(
+            raw_column['column_name'],
+            raw_column['column_default'],
+            raw_column['data_type_id'],
+            raw_column['table_name'],
+            raw_column['data_type'],
+            raw_column['is_nullable'],
+            raw_column['is_identity']
+        )
+      end
+
+      return columns
+    end
+
     def self.current_time
       ::ActiveRecord::Base.default_timezone == :utc ? ::Time.now.utc : ::Time.now
     end

--- a/lib/arjdbc/vertica/column.rb
+++ b/lib/arjdbc/vertica/column.rb
@@ -2,14 +2,21 @@ module ActiveRecord
 
   module ConnectionAdapters
     class VerticaColumn < Column
-      def initialize(name, default, data_type_id, sql_type = nil, null = true, primary_key = false)
+      def initialize(name, default, data_type_id, table_name, sql_type = nil, null = true, default_function = nil, primary_key = false)
         super(name,
-              self.class.extract_value_from_default(default),
-              self.class.cast_type_from_data_type_id(data_type_id) || self.class.cast_type_from_sql_type(sql_type),
-              sql_type,
-              null)
+              default = self.class.extract_value_from_default(default),
+              self.class.sql_type_metadata(sql_type, data_type_id),
+              null,
+              table_name
+        )
+
         # Might need to set if it is primary key below? don't know
         # self.primary = primary_key
+      end
+
+      def self.sql_type_metadata(sql_type, data_type_id)
+        cast_type = self.cast_type_from_data_type_id(data_type_id) || self.cast_type_from_sql_type(sql_type)
+        ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(sql_type: sql_type, type: cast_type.type, limit: cast_type.limit, precision: cast_type.precision, scale: cast_type.scale)
       end
 
       def self.cast_type_from_data_type_id(data_type_id)


### PR DESCRIPTION
With Rails 5, there was a significant change to  https://github.com/jruby/activerecord-jdbc-adapter  v51, which handles the  the base abstract adapter for ARJDBC.

These changes are the first steps in getting the vertica implementation of the activerecord-jdbc-adapter for Rails 5.

I'll be the first to admit that my knowledge in this area is severely limited, but at least ballista can connect and run the vertica db now. 

The code as is meets the bare minimum of functionality and i'd love to learn more about JDBC and activerecord and get this to a great code change instead of a functional one 😄 

After testing this out in sand, turns out this is more along the lines of what we would call `barely functional`