### PR TITLE
Revert to the verbose version

### DIFF
--- a/lib/arjdbc/vertica/adapter.rb
+++ b/lib/arjdbc/vertica/adapter.rb
@@ -279,9 +279,13 @@ module ::ArJdbc
     end
 
     def type_to_sql(type, limit = nil, precision = nil, scale = nil) #:nodoc:
-      super unless type.to_sym == :integer
+      super unless type == :integer
 
-      native_database_types[:integer][:name].dup
+      if native = native_database_types[type.to_sym]
+        (native.is_a?(Hash) ? native[:name] : native).dup
+      else
+        type.to_s
+      end
     end
 
   end

--- a/lib/arjdbc/vertica/adapter.rb
+++ b/lib/arjdbc/vertica/adapter.rb
@@ -279,7 +279,7 @@ module ::ArJdbc
     end
 
     def type_to_sql(type, limit = nil, precision = nil, scale = nil) #:nodoc:
-      super unless type == :integer
+      super unless type.to_sym == :integer
 
       if native = native_database_types[type.to_sym]
         (native.is_a?(Hash) ? native[:name] : native).dup


### PR DESCRIPTION
@film42 

Don't ask me why but when we "simplified" this code it caused a problem where EVERY single field type got set to `int` no matter what it should have been.

I verified that this version correctly does the migration and sets the right type.