### PR TITLE
Pass the column size/limit to the parent method

### DIFF
--- a/lib/arjdbc/vertica/adapter.rb
+++ b/lib/arjdbc/vertica/adapter.rb
@@ -283,9 +283,12 @@ module ::ArJdbc
       super unless (type.to_sym == :integer || type.to_sym == :bigserial)
 
       if native = native_database_types[type.to_sym]
-        (native.is_a?(Hash) ? native[:name] : native).dup
-      else
-        type.to_s
+        if native.is_a?(Hash)
+          type, limit = native[:name], native[:limit]
+          super
+        else
+          native.to_s
+        end
       end
     end
 

--- a/spec/migrations/column_spec.rb
+++ b/spec/migrations/column_spec.rb
@@ -36,6 +36,11 @@ describe ColumnKing do
       columns.find { |column| column.name == "#{name}" }.sql_type =~ type)
   end
 
+  def has_column_limit?(name, type, limit)
+    !!(has_column_typed?(name, type) &&
+      columns.find { |column| column.name == "#{name}" }.sql_type.to_s.gsub(/\D/, "").to_i == limit)
+  end
+
   before do
     ColumnKing.drop_kings
     ColumnKing.up
@@ -64,12 +69,14 @@ describe ColumnKing do
       connection.add_column(:kings, :name, :string)
       has_column?(:name).must_equal(true)
       has_column_typed?(:name, /varchar/i).must_equal(true)
+      has_column_limit?(:lineage, /varchar/i, 255).must_equal(true)
     end
 
     it "creates :text columns (as varchar columns)" do
       connection.add_column(:kings, :lineage, :text)
       has_column?(:lineage).must_equal(true)
       has_column_typed?(:lineage, /varchar/i).must_equal(true)
+      has_column_limit?(:lineage, /varchar/i, 15000).must_equal(true)
     end
   end
 


### PR DESCRIPTION
We're seeing `varchar(80)` field sizes in Vertica for fields defined as either `string` or `text`. This change should fix this issue by passing the `limit` option from the `NATIVE_DATABASE_TYPES` constant back to the calling method.